### PR TITLE
Benchmark against Sentry submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "benches/getsentry/sentry"]
+	path = benches/getsentry/sentry
+	url = git@github.com:getsentry/sentry.git

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Most of the time, your pre-commit will be running on a small number of files, so
 $ cargo bench
 ```
 
+The results will then be viewable at `target/criterion/report/index.html`.
+
 ## Alternative tools
 
 Even if `ripsecrets` is not the right tool for you, if you're working on a service that deals with user data you should strongly consider using a secret scanner. Here are some alternative tools worth considering:

--- a/benches/find_secrets.rs
+++ b/benches/find_secrets.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("Find secrets in getsentry/sentry");
     group
-        .sample_size(150)
+        .sample_size(30)
         .measurement_time(Duration::new(15, 0));
     let paths = &[PathBuf::from("./benches/getsentry/sentry")];
 

--- a/benches/find_secrets.rs
+++ b/benches/find_secrets.rs
@@ -4,11 +4,11 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Find secrets in self");
+    let mut group = c.benchmark_group("Find secrets in getsentry/sentry");
     group
         .sample_size(150)
         .measurement_time(Duration::new(15, 0));
-    let paths = &[PathBuf::from("./test")];
+    let paths = &[PathBuf::from("./benches/getsentry/sentry")];
 
     group.bench_function("find_secrets function", |b| {
         b.iter(|| find_secrets(black_box(paths), false))

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
 
           # `nix develop`
           devShell = pkgs.mkShell {
-            nativeBuildInputs = with pkgs; [ rustc cargo libiconv ];
+            nativeBuildInputs = with pkgs; [ cargo gnuplot libiconv rustc ];
           };
         }
     );


### PR DESCRIPTION
This is intended to address concerns about reproducibility raised in sirwart/ripsecrets#25. As [I commented](https://github.com/sirwart/ripsecrets/pull/25#issuecomment-1236364673) on that issue:
> Git submodules natively use specific SHAs, so bit-for-bit reproducibility of the test data would be handled for us.