### PR TITLE
Use `cargo-criterion` as the benchmark runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,13 @@ Most of the time, your pre-commit will be running on a small number of files, so
 
 ## Running benchmarks
 
+Some one-time setup is required:
+1. Install [cargo-criterion](https://github.com/bheisler/cargo-criterion): `cargo install cargo-criterion`. Note that step is not needed if using Nix Flake.
+1. Initialize all Git submodules: `git submodule init && git submodule update`. Benchmarks are performed against the [Sentry repo](https://github.com/getsentry/sentry), which is included as a submodule.
+
+To actually run the benchmarks:
 ```shell
-$ cargo bench
+$ cargo criterion
 ```
 
 The results will then be viewable at `target/criterion/report/index.html`.

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,13 @@
 
           # `nix develop`
           devShell = pkgs.mkShell {
-            nativeBuildInputs = with pkgs; [ cargo gnuplot libiconv rustc ];
+            nativeBuildInputs = with pkgs; [
+              cargo
+              cargo-criterion
+              gnuplot
+              libiconv
+              rustc
+            ];
           };
         }
     );


### PR DESCRIPTION
This avoids deprecation warnings when running `criterion` under `cargo bench`.